### PR TITLE
Fixed incorrect HID_EPIN_SIZE

### DIFF
--- a/firmware/Middlewares/ST/STM32_USB_Device_Library/Class/HID/Inc/usbd_hid.h
+++ b/firmware/Middlewares/ST/STM32_USB_Device_Library/Class/HID/Inc/usbd_hid.h
@@ -50,7 +50,7 @@
   * @{
   */ 
 #define HID_EPIN_ADDR                 0x81
-#define HID_EPIN_SIZE                 0x40
+#define HID_EPIN_SIZE                 0x04
 
 #define USB_HID_CONFIG_DESC_SIZ       34
 #define USB_HID_DESC_SIZ              9


### PR DESCRIPTION
Fixed a typo that prevented the HID keyboard from working.
